### PR TITLE
Remove double scrollbars from old gui pages.

### DIFF
--- a/iml-old-gui.spec.template
+++ b/iml-old-gui.spec.template
@@ -32,6 +32,8 @@ rm -rf %{buildroot}
 %{nodejs_sitelib}
 
 %changelog
+* Fri Oct 26 2018 Will Johnson <wjohnson@whamcloud.com> - 3.0.1-1
+- Fix double scrollbar issue
 * Tue Jun 19 2018 Joe Grund <jgrund@whamcloud.com> - 3.0.0-1
 - Build using FAKE
 - Initial standalone RPM package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/old-gui",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/old-gui",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "scripts": {
     "test": "karma start",

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -358,6 +358,10 @@ tr.log_info {
   overflow:auto;
 }
 
+div.toplevel {
+    overflow-y: hidden;
+}
+
 div.toplevel, div.relative {
     position: relative;
     background-color: white;


### PR DESCRIPTION
The old gui is displayed in an iframe and causes multiple scrollbars to appear in both firefox and chrome. The vertical scrollbars should be
disabled inside the old gui so that the outer gui can manage them.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>