### PR TITLE
Filesystem Detail Chart shows incorrect units for storage statistics

### DIFF
--- a/static/js/lib/format-big-number.js
+++ b/static/js/lib/format-big-number.js
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-function formatBigNumber (num, precision, strict = false) {
+export default function (num, precision, strict = false) {
   const units = ['', 'k', 'M', 'B', 'T'];
   num = $.isNumeric(num) ? num : 0;
   precision = $.isNumeric(precision) ? precision : 3;

--- a/static/js/lib/format-big-number.js
+++ b/static/js/lib/format-big-number.js
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+function formatBigNumber (num, precision, strict = false) {
+  const units = ['', 'k', 'M', 'B', 'T'];
+  num = $.isNumeric(num) ? num : 0;
+  precision = $.isNumeric(precision) ? precision : 3;
+
+  const sign = num < 0 ? '-' : '';
+  num = Math.abs(num);
+
+  let pwr = Math.floor(Math.log(num) / Math.log(1000));
+
+  pwr = Math.min(pwr, units.length - 1);
+  pwr = Math.max(pwr, 0);
+  num /= Math.pow(1000, pwr);
+
+  const formatOptions = {
+    maximumSignificantDigits: precision,
+    maximumFractionDigits: precision
+  };
+
+  if (strict) formatOptions.minimumSignificantDigits = precision;
+
+  const formatter = new Intl.NumberFormat('en-us', formatOptions);
+
+  return sign + formatter.format(num) + units[pwr];
+};

--- a/static/js/lib/format-bytes.js
+++ b/static/js/lib/format-bytes.js
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+function formatBytes (bytes, precision) {
+  const units = ['B', 'kiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+
+  if (isNaN(parseFloat(bytes)) || !isFinite(bytes)) return '';
+  precision = precision || 4;
+
+  bytes = Math.max(bytes, 0);
+  let pwr = Math.floor(Math.log(bytes) / Math.log(1024));
+  pwr = Math.min(pwr, units.length - 1);
+  pwr = Math.max(pwr, 0);
+  bytes /= Math.pow(1024, pwr);
+  return `${bytes.toPrecision(precision)} ${units[pwr]}`;
+};

--- a/static/js/lib/format-bytes.js
+++ b/static/js/lib/format-bytes.js
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-function formatBytes (bytes, precision) {
+export default function (bytes, precision) {
   const units = ['B', 'kiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
 
   if (isNaN(parseFloat(bytes)) || !isFinite(bytes)) return '';

--- a/static/js/misc.js
+++ b/static/js/misc.js
@@ -3,107 +3,44 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-
-
-/* returns a floating point nubmer with fixed precision */
-function formatNumberPrecision(number, precision) {
-
-    var n = number;
-    var s = n < 0 ? "-" : "";
-    var p = isNaN(precision = Math.abs(precision)) ? 3 : precision;
-    return s +  parseFloat(Math.abs(+n || 0).toPrecision(p));
-}
-
-/* precision is how many significant digits to keep */
-function formatBytes(bytes, precision) {
-  if (bytes == null || bytes == undefined) {
-    return bytes;
-  }
-  if (precision == undefined) {
-    precision = 3;
-  }
-
-  if (bytes > Math.pow(2, 40)) {
-    bytes = formatNumberPrecision(bytes / Math.pow(2, 40), precision) + 'TB';
-  } else {
-    if (bytes >= 1073741824) {
-      bytes = formatNumberPrecision(bytes / 1073741824, precision) + 'GB';
-    } else {
-      if (bytes >= 1048576) {
-        bytes = formatNumberPrecision(bytes / 1048576, precision) + 'MB';
-      } else {
-        if (bytes >= 1024) {
-          bytes = formatNumberPrecision(bytes / 1024, precision) + 'KB';
-        } else {
-          bytes = formatNumberPrecision(bytes, precision) + 'b';
+/* https://docs.djangoproject.com/en/1.2/ref/contrib/csrf/#csrf-ajax */
+$(document).ajaxSend(function(event, xhr, settings) {
+  function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie != "") {
+      var cookies = document.cookie.split(";");
+      for (var i = 0; i < cookies.length; i++) {
+        var cookie = jQuery.trim(cookies[i]);
+        // Does this cookie string begin with the name we want?
+        if (cookie.substring(0, name.length + 1) == name + "=") {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
         }
       }
     }
+    return cookieValue;
   }
-  return bytes;
-}
-
-function formatKBytes(kbytes, precision) {
-  return formatBytes(kbytes * 1024, precision);
-}
-
-function formatBigNumber(number, precision) {
-  if (number == null || number == undefined) {
-    return number;
+  function sameOrigin(url) {
+    // url could be relative or scheme relative or absolute
+    var host = document.location.host; // host + port
+    var protocol = document.location.protocol;
+    var sr_origin = "//" + host;
+    var origin = protocol + sr_origin;
+    // Allow absolute or scheme relative URLs to same origin
+    return (
+      url == origin ||
+      url.slice(0, origin.length + 1) == origin + "/" ||
+      (url == sr_origin ||
+        url.slice(0, sr_origin.length + 1) == sr_origin + "/") ||
+      // or any other URL that isn't scheme relative or absolute i.e relative.
+      !/^(\/\/|http:|https:).*/.test(url)
+    );
   }
-  if (precision == undefined) {
-    precision = 3;
+  function safeMethod(method) {
+    return /^(GET|HEAD|OPTIONS|TRACE)$/.test(method);
   }
 
-	if (number >= 1000000000) {
-	     number = formatNumberPrecision(number / 1000000000, precision) + 'B';
-	} else { 
-		if (number >= 1000000) {
-     		number = formatNumberPrecision(number / 1000000, precision) + 'M';
-   	} else { 
-			if (number >= 1000) {
-    		number = formatNumberPrecision(number / 1000, precision) + 'k';
-  		}
- 		}
-	}
-  return number;
-}
-
-/* https://docs.djangoproject.com/en/1.2/ref/contrib/csrf/#csrf-ajax */
-$(document).ajaxSend(function(event, xhr, settings) {
-    function getCookie(name) {
-        var cookieValue = null;
-        if (document.cookie && document.cookie != '') {
-            var cookies = document.cookie.split(';');
-            for (var i = 0; i < cookies.length; i++) {
-                var cookie = jQuery.trim(cookies[i]);
-                // Does this cookie string begin with the name we want?
-                if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                    break;
-                }
-            }
-        }
-        return cookieValue;
-    }
-    function sameOrigin(url) {
-        // url could be relative or scheme relative or absolute
-        var host = document.location.host; // host + port
-        var protocol = document.location.protocol;
-        var sr_origin = '//' + host;
-        var origin = protocol + sr_origin;
-        // Allow absolute or scheme relative URLs to same origin
-        return (url == origin || url.slice(0, origin.length + 1) == origin + '/') ||
-            (url == sr_origin || url.slice(0, sr_origin.length + 1) == sr_origin + '/') ||
-            // or any other URL that isn't scheme relative or absolute i.e relative.
-            !(/^(\/\/|http:|https:).*/.test(url));
-    }
-    function safeMethod(method) {
-        return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
-    }
-
-    if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
-        xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
-    }
+  if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
+    xhr.setRequestHeader("X-CSRFToken", getCookie("csrftoken"));
+  }
 });
-

--- a/templates/base.html
+++ b/templates/base.html
@@ -95,6 +95,8 @@
         <script type="text/javascript" src="/old-gui/js/modules/exception/disconnect-dialog.js"></script>
         <script type="text/javascript" src="/old-gui/js/modules/exception/replay.js"></script>
 
+        <script type="text/javascript" src="/old-gui/js/lib/format-bytes.js"></script>
+        <script type="text/javascript" src="/old-gui/js/lib/format-big-number.js"></script>
         <script type="text/javascript" src="/old-gui/js/misc.js"></script>
         <script type='text/javascript'>
           window.TIME_OFFSET = Math.round((new Date(<$= getServerDate().getTime() $>) - new Date()) / 1000);

--- a/templates/base.html
+++ b/templates/base.html
@@ -95,8 +95,14 @@
         <script type="text/javascript" src="/old-gui/js/modules/exception/disconnect-dialog.js"></script>
         <script type="text/javascript" src="/old-gui/js/modules/exception/replay.js"></script>
 
-        <script type="text/javascript" src="/old-gui/js/lib/format-bytes.js"></script>
-        <script type="text/javascript" src="/old-gui/js/lib/format-big-number.js"></script>
+        <script type="module">
+          import formatBytes from "/old-gui/js/lib/format-bytes.js";
+          window.formatBytes = formatBytes;
+        </script>
+        <script type="module">
+          import formatBigNumber from "/old-gui/js/lib/format-big-number.js";
+          window.formatBigNumber = formatBigNumber;
+        </script>
         <script type="text/javascript" src="/old-gui/js/misc.js"></script>
         <script type='text/javascript'>
           window.TIME_OFFSET = Math.round((new Date(<$= getServerDate().getTime() $>) - new Date()) / 1000);


### PR DESCRIPTION
Fixes #22.

The storage metrics on the filesystem detail page and targets should be calculated using the number-formatters algorithm. Unfortunately, the old gui will not allow the repo to be included and bundled, so for now I think it makes sense to replace the functionality in misc.js with the logic in number-formatters.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>