### PR TITLE
Remove `hsm_control_params` on fs detail action

### DIFF
--- a/templates/filesystem_detail.html
+++ b/templates/filesystem_detail.html
@@ -441,10 +441,13 @@
 
               const actionDropdown = document.querySelector('#fs_actions div');
 
+              let fs = {...filesystem};
+              delete fs.hsm_control_params;
+
               window.generateCommandDropdown.generateDropdown(
                 actionDropdown, 
                 {
-                  ...filesystem,
+                  ...fs,
                   available_actions: [...action_data.objects]
                 }, 
                 'right'


### PR DESCRIPTION
Remove `hsm_control_params` on fs detail action so
the filesystem detail action_dropdown shows the right thing.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>