### PR TITLE
Fix volumes not appearing on volumes page

### DIFF
--- a/templates/volume_tab.html
+++ b/templates/volume_tab.html
@@ -388,7 +388,7 @@
        * @returns {Object} A promise.
        */
       function fetchVolumes () {
-        return $.get('/api/volume?limit=0&category=unused')
+        return $.get('/api/volume/?limit=0&category=unused')
           .then(function (data) {
             data.objects.forEach(decorateVolumeRow);
 


### PR DESCRIPTION
Fixes GUI#201

Description:

When the volumes page loads it makes an asynchronouse call to https://localhost:7443/api/volume?limit=0&category=unused.
The problem is that nginx proxies this request over to gunicorn, where
it then generates a 301 to http://localhost:7443/api/volume/?limit=0&category=unused. This would normally be ok as when it
get sent back to nginx it would 302 to https://localhost:7443/api/volume/?limit=0&category=unused, but because the url changed
from https to http the csp is not satisfied and the request is then
canceled. I belive there are two things that need to be done to solve
this issue:

- redirect api calls to always have a trailing slash before being
proxied to gunicorn
- Update existing api calls that do not have a trailing slash

This patch addresses the second item.

Signed-off-by: Will Johnson wjohnson@whamcloud.com